### PR TITLE
Modifica programma, patto educativo e valutazione

### DIFF
--- a/about.md
+++ b/about.md
@@ -40,9 +40,9 @@ width="375" height="265">
 Il corso è destinato principalmente alle associazioni e alle scuole che hanno aderito al progetto DOORS.
 
 ## Obiettivi
-- Conoscere l’apprendimento creativo per progettare attività educative
+- Conoscere l’Apprendimento Creativo per progettare attività educative
 - Scoprire Scratch come strumento per aiutare ragazze e ragazzi ad essere fruitori attivi e creativi della tecnologia
-- Esplorare il tinkering e le esperienze di apprendimento basato sul “fare con le mani”
+- Esplorare il Tinkering e le esperienze di apprendimento basato sul “fare con le mani”
 - Apprendere nuove strategie di facilitazione di esperienze di apprendimento
 - Conoscere le metodologie di sviluppo collaborativo
 - Scoprire i vantaggi del software libero e della conoscenza libera
@@ -52,56 +52,50 @@ Il corso è destinato principalmente alle associazioni e alle scuole che hanno a
 - Learning through/by making 
 - Costruzionismo
 
-## Orario del corso
-
-#### Gruppo Milano/Torino
-
-La formazione si svolgerà dall’8 febbraio al 30 marzo 2021 in modalità mista, sincrona e
-asincrona (impegno totale 24 ore)
-
-OGNI SETTIMANA Verranno condiVisi materiali, risorse di approfondimento e attività da svolgere
-
-TUTTI I MARTEDÌ dal 16/02/2021 al 16/03/2021, ore 16.30-18.30 si terrà un laboratorio online tramite la piattaforma open source Jitsi 
-
-CONDIVISIONE DEI PROGETTI FINALI (incontro online 30 marzo ore 17.30-18.30)
-
-#### Gruppo Villa San Giovanni (RC)
-
-La formazione si svolgerà dall’8 febbraio al 31 marzo 2021 in modalità mista, sincrona e
-asincrona (impegno totale 24 ore)
-
-OGNI SETTIMANA Verranno condiVisi materiali, risorse di approfondimento e attività da svolgere
-
-TUTTI I MERCOLEDÌ dal 17/02/2021 al 17/03/2021, ore 16.30-18.30 si terrà un laboratorio online tramite la piattaforma open source Jitsi 
-
-CONDIVISIONE DEI PROGETTI FINALI (incontro online 31 marzo ore 17.30-18.30)
 
 ## Programma (edizione online)
 
-INIZIO FORMAZIONE - 8 febbraio
-I partecipanti ricevono via mail video introduttivi che permettono di iniziare a sperimentare in modo autonomo l’ambiente Scratch
+La formazione si svolgerà dall’8 febbraio al 30 marzo 2021 in modalità mista, sincrona e asincrona (impegno totale 24 ore).
 
-PRIMA SETTIMANA - (incontro online 16 febbraio)
+Ogni settimana verranno condivisi via mail e su questo sito materiali, risorse di approfondimento e attività da svolgere. Inoltre, a partire dalla seconda settimana di corso, si terranno dei laboratori "dal vivo" online sulla piattaforma open source Jitsi.
+
+PRIMA SETTIMANA
+I partecipanti ricevono via mail video introduttivi che permettono di iniziare a sperimentare in modo autonomo l’ambiente Scratch.
+
+SECONDA SETTIMANA
 - Introduzione a Scratch: “Nome Animato”
 - Introduzione al Creative Learning
 
-SECONDA SETTIMANA - (incontro sincrono 23 febbraio)
-- Dal mondo fisico al mondo digitale: “Collage conScratch”
+TERZA SETTIMANA
+- Dal mondo fisico al mondo digitale: “Collage con Scratch”
 - Imparare e giocare
 
-TERZA SETTIMANA - (incontro online 2 marzo)
+QUARTA SETTIMANA
 - Tinkering: “Esplorare con le mani”
 - Imparare per prove ed errori
 
-QUARTA SETTIMANA - (incontro online 9 marzo)
+QUINTA SETTIMANA
 - Il potere del Remix con Scratch: “Pass it on”
 - Software libero e apprendimento collaborativo
 
-QUINTA SETTIMANA - (incontro online 16 marzo)
+SESTA SETTIMANA
 - Ideazione progetto finale
 - Realizzazione progetto finale
 
 CONDIVISIONE DEI PROGETTI FINALI
+
+## Orari dei corsi
+
+### Gruppo Milano/Torino
+
+Laboratorio online: i **MARTEDÌ** dal 16/02/2021 al 16/03/2021, ore 16.30-18.30 
+Incontro finale di condivisione: martedì 30 marzo, ore 17.30-18.30
+
+### Gruppo Villa San Giovanni (RC)
+
+Laboratorio online: i **MERCOLEDÌ** dal 17/02/2021 al 17/03/2021, ore 16.30-18.30
+Incontro finale di condivisione: mercoledì 31 marzo, ore 17.30-18.30
+
 
 ## Prerequisiti e dotazione necessaria
 - PC o laptop (browser: Chrome, Chromium, Firefox)
@@ -109,12 +103,8 @@ CONDIVISIONE DEI PROGETTI FINALI
 - Webcam e auricolari
 - Tutta la vostra voglia di sperimentare e divertirvi
 
+
 ## Patto educativo
 
-Seymour Papert esorta ad apprendere divertendosi con qualcosa di impegnativo: *Hard Fun*. 
-I formatori e i tutor si impegnano a facilitare questa modalità di apprendimento e i discenti a raccogliere la sfida.
-
-Divertiamoci realizzando progetti complessi e arditi!
-
-## Valutazione
-Diario di apprendimento
+Apprendere l'Apprendimento Creativo richiedere di sperimentarlo in prima persona, creando, condividendo e giocando. Per questo invitiamo i partecipanti a togliere il cappello da insegnanti e indossare il cappello di chi apprende.
+I formatori e i tutor si impegnano a creare un ambiente che faccia sentire i partecipanti a loro agio e sostenuti, i partecipanti si impegnano a dare il massimo in ogni attività.


### PR DESCRIPTION
Abbiamo provato a spiegare meglio il programma e le date, visto che sono 2 gruppi distinti che leggeranno la stessa pagina.
Abbiamo rivisitato il patto educativo per abbassare il pavimento e rendere più chiaro il cambio di paradigma che gli chiediamo di fare.
Abbiamo rimosso la parte "Valutazione" per evitare di farli entrare in una logica performativa.